### PR TITLE
Moved @fab/cf-workers and @fab/nextjs to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
     "start": "next start"
   },
   "dependencies": {
-    "@fab/cf-workers": "^0.0.5",
-    "@fab/nextjs": "^0.4.0-0",
     "next": "9.0.5",
     "next-images": "^1.1.2",
     "react": "16.9.0",
     "react-dom": "16.9.0"
+  },
+  "devDependencies": {
+    "@fab/cf-workers": "^0.0.5",
+    "@fab/nextjs": "^0.4.0-0"
   }
 }


### PR DESCRIPTION
These files were previously in `dependencies`, but since they aren't used at runtime, they should be `devDependencies` instead.